### PR TITLE
Add testing for loading and indexing Bible text file

### DIFF
--- a/lib/services/bible/bible.dart
+++ b/lib/services/bible/bible.dart
@@ -6,7 +6,7 @@ abstract class Bible {
   Bible();
 
   Bible.fromLines(dynamic lines, [Verse parseLine(String line)]) {
-    indexedBible = _indexAllLines(lines, parseLine);
+    indexedBible = _indexAllLines(lines, parseLine ?? defaultParseLine);
   }
 
   String get language;
@@ -67,7 +67,7 @@ abstract class Bible {
 
   List<List<List<Verse>>> _indexAllLines(
       dynamic lines, Verse parseLine(String line)) {
-    final book = List<List>(numBooks);
+    final book = List<List<List<Verse>>>(numBooks);
     for (int i = 0; i < numBooks; i++) {
       // Assign correct number of chapters
       final chapterCount = bookToNumChapters[i];
@@ -76,7 +76,7 @@ abstract class Bible {
 
     lines.forEach((line) {
       Verse v = parseLine(line);
-      book[v.book][v.chapter - 1][v.verse - 1] = v.text;
+      book[v.book][v.chapter - 1].add(v);
     });
 
     return book;
@@ -112,6 +112,7 @@ abstract class Bible {
   }
 
   static const int numBooks = 66;
+  static const int numVerses = 31102;
   static const bookToNumChapters = [
     50,
     40,

--- a/test/unit/lib/services/bible/korean_bible_test.dart
+++ b/test/unit/lib/services/bible/korean_bible_test.dart
@@ -1,13 +1,63 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:interprep/services/bible/bible.dart';
 import 'package:interprep/services/bible/korean_bible.dart';
 import 'package:interprep/services/bible/verse.dart';
 
 void main() {
+  group('Constructor fromLines', () {
+    test('produces correctly indexed Bible', () {
+      final lines = File('assets/KoreanVer.txt').readAsLinesSync();
+      final bible = KoreanBible.fromLines(lines);
+
+      expect(bible.indexedBible.length, Bible.numBooks);
+      expect(
+          bible.indexedBible
+              .map((b) => b.map((c) => c.length).reduce((j, k) => j + k))
+              .reduce((j, k) => j + k),
+          Bible.numVerses);
+      expect(bible.indexedBible.map((b) => b.length), Bible.bookToNumChapters);
+
+      bible.indexedBible.asMap().forEach((i, b) {
+        b.asMap().forEach((j, c) {
+          c.asMap().forEach((k, v) {
+            expect(v.book, i);
+            expect(v.chapter, j + 1);
+            expect(v.verse, k + 1);
+          });
+        });
+      });
+    });
+  });
+
   test('language is Korean', () {
     expect(KoreanBible().language, 'Korean');
   });
 
-  group('getBookIndex(String book)', () {
+  group('hasChapter()', () {
+    test('returns false if book is negative', () {
+      expect(KoreanBible().hasChapter(-1, 0), false);
+    });
+
+    test('returns false if book is out of range', () {
+      expect(KoreanBible().hasChapter(66, 0), false);
+    });
+
+    test('returns false if chapter is nonpositive', () {
+      expect(KoreanBible().hasChapter(0, 0), false);
+    });
+
+    test('returns false if chapter is out of range', () {
+      expect(KoreanBible().hasChapter(0, 51), false);
+    });
+
+    test('returns true if book and chapter are in range', () {
+      expect(KoreanBible().hasChapter(0, 50), true);
+    });
+  });
+
+  group('getBookIndex()', () {
     test('returns -1 if book is empty', () {
       expect(KoreanBible().getBookIndex(''), -1);
     });

--- a/test/unit/lib/services/bible/korean_bible_test.dart
+++ b/test/unit/lib/services/bible/korean_bible_test.dart
@@ -3,6 +3,29 @@ import 'package:interprep/services/bible/korean_bible.dart';
 import 'package:interprep/services/bible/verse.dart';
 
 void main() {
+  test('language is Korean', () {
+    expect(KoreanBible().language, 'Korean');
+  });
+
+  group('getBookIndex(String book)', () {
+    test('returns -1 if book is empty', () {
+      expect(KoreanBible().getBookIndex(''), -1);
+    });
+
+    test('searches shortened names first', () {
+      // Without that search, this will result in getting 요나 instead 요한복음
+      expect(KoreanBible().getBookIndex('요'), 42);
+    });
+
+    test('returns first index that contains string', () {
+      expect(KoreanBible().getBookIndex('굽'), 1);
+    });
+
+    test('works with full book name', () {
+      expect(KoreanBible().getBookIndex('사무엘상'), 8);
+    });
+  });
+
   group('defaultParseLine()', () {
     test('successfully parses usual line', () {
       final line = '창1:1 태초에 하나님이 천지를 창조하시니라';

--- a/test/unit/lib/services/bible/nkjv_bible_test.dart
+++ b/test/unit/lib/services/bible/nkjv_bible_test.dart
@@ -1,10 +1,60 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:interprep/services/bible/bible.dart';
 import 'package:interprep/services/bible/nkjv_bible.dart';
 import 'package:interprep/services/bible/verse.dart';
 
 void main() {
+  group('Constructor fromLines', () {
+    test('produces correctly indexed Bible', () {
+      final lines = File('assets/NKJVer.txt').readAsLinesSync();
+      final bible = NkjvBible.fromLines(lines);
+
+      expect(bible.indexedBible.length, Bible.numBooks);
+      expect(
+          bible.indexedBible
+              .map((b) => b.map((c) => c.length).reduce((j, k) => j + k))
+              .reduce((j, k) => j + k),
+          Bible.numVerses);
+      expect(bible.indexedBible.map((b) => b.length), Bible.bookToNumChapters);
+
+      bible.indexedBible.asMap().forEach((i, b) {
+        b.asMap().forEach((j, c) {
+          c.asMap().forEach((k, v) {
+            expect(v.book, i);
+            expect(v.chapter, j + 1);
+            expect(v.verse, k + 1);
+          });
+        });
+      });
+    });
+  });
+
   test('language is English', () {
     expect(NkjvBible().language, 'English');
+  });
+
+  group('hasChapter()', () {
+    test('returns false if book is negative', () {
+      expect(NkjvBible().hasChapter(-1, 0), false);
+    });
+
+    test('returns false if book is out of range', () {
+      expect(NkjvBible().hasChapter(66, 0), false);
+    });
+
+    test('returns false if chapter is nonpositive', () {
+      expect(NkjvBible().hasChapter(0, 0), false);
+    });
+
+    test('returns false if chapter is out of range', () {
+      expect(NkjvBible().hasChapter(0, 51), false);
+    });
+
+    test('returns true if book and chapter are in range', () {
+      expect(NkjvBible().hasChapter(0, 50), true);
+    });
   });
 
   group('getBookIndex(String book)', () {

--- a/test/unit/lib/services/bible/nkjv_bible_test.dart
+++ b/test/unit/lib/services/bible/nkjv_bible_test.dart
@@ -3,6 +3,29 @@ import 'package:interprep/services/bible/nkjv_bible.dart';
 import 'package:interprep/services/bible/verse.dart';
 
 void main() {
+  test('language is English', () {
+    expect(NkjvBible().language, 'English');
+  });
+
+  group('getBookIndex(String book)', () {
+    test('returns -1 if book is empty', () {
+      expect(NkjvBible().getBookIndex(''), -1);
+    });
+
+    test('searches shortened names first', () {
+      // Without that search, this will result in getting Genesis instead of Isaiah
+      expect(NkjvBible().getBookIndex('is'), 22);
+    });
+
+    test('returns first index that contains string', () {
+      expect(NkjvBible().getBookIndex('odu'), 1);
+    });
+
+    test('works with full book name', () {
+      expect(NkjvBible().getBookIndex('1 Samuel'), 8);
+    });
+  });
+
   group('defaultParseLine()', () {
     test('successfully parses usual line', () {
       final line =


### PR DESCRIPTION
- Write test for `.fromLines` constructor that loads directly the asset file and indexes it.
- Some more tests for other methods.
- Fixed some issues in `Bible` class that were found while testing.