### PR TITLE
Connect ui to logic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:interprep/services/bible/passage.dart';
 import 'package:interprep/services/bible/verse.dart';
 import 'package:interprep/services/bible_source.dart';
+import 'package:interprep/services/formatter/two_column_format.dart';
 import 'package:interprep/services/formatter/two_line_format.dart';
 import 'services/bible/korean_bible.dart';
 import 'services/bible/nkjv_bible.dart';
@@ -103,23 +104,27 @@ class _CardInterfaceState extends State<CardInterface> {
         labelText: 'Book Name',
         isDense: true,
       ),
-      textSubmitted: (text) => setState(() {
-        _currentBook = text;
-        bookName.text = text;
-        print(_currentBook);
-      }),
+      textSubmitted: (text) => print(text),
     );
   }
 
   void copyVerse() {
-    final book = koreanBible.getBookIndex(_currentBook) ??
-        nkjvBible.getBookIndex(_currentBook);
+    int book = koreanBible.getBookIndex(_currentBook);
+    if (book == -1) book = nkjvBible.getBookIndex(_currentBook);
     final v1 = Verse(null, book, _currentChapter, _currentStartVerse, null);
     final v2 = Verse(null, book, _currentChapter, _currentEndVerse, null);
     final korean = Passage(koreanBible, v1, v2);
     final nkjv = Passage(nkjvBible, v1, v2);
 
-    final str = TwoLineFormat().formatPassagePair(korean, nkjv);
+    String str;
+    if (_verseStatus == VerseStatus.recited) {
+      final locationFirst = _verseLocation == VerseLocation.before;
+      str = TwoLineFormat().formatPassagePair(korean, nkjv,
+          locationFirst: locationFirst, useAbbreviation1: true);
+    } else {
+      str = TwoColumnFormat()
+          .formatPassagePair(korean, nkjv, useAbbreviation1: true);
+    }
     Clipboard.setData(ClipboardData(text: str));
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:autocomplete_textfield/autocomplete_textfield.dart';
 import 'package:flutter/services.dart';
+import 'package:interprep/services/bible/passage.dart';
+import 'package:interprep/services/bible/verse.dart';
 import 'package:interprep/services/bible_source.dart';
+import 'package:interprep/services/formatter/two_line_format.dart';
 import 'services/bible/korean_bible.dart';
 import 'services/bible/nkjv_bible.dart';
 
@@ -108,9 +111,17 @@ class _CardInterfaceState extends State<CardInterface> {
     );
   }
 
-  // void copyVerse() {
-  //   Clipboard.setData(ClipboardData(text: _currentBook));
-  // }
+  void copyVerse() {
+    final book = koreanBible.getBookIndex(_currentBook) ??
+        nkjvBible.getBookIndex(_currentBook);
+    final v1 = Verse(null, book, _currentChapter, _currentStartVerse, null);
+    final v2 = Verse(null, book, _currentChapter, _currentEndVerse, null);
+    final korean = Passage(koreanBible, v1, v2);
+    final nkjv = Passage(nkjvBible, v1, v2);
+
+    final str = TwoLineFormat().formatPassagePair(korean, nkjv);
+    Clipboard.setData(ClipboardData(text: str));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -347,8 +358,7 @@ class _CardInterfaceState extends State<CardInterface> {
                         color: Colors.blue,
                         textColor: Colors.white,
                         onPressed: () {
-                          //Do COPY VERSE ACTION
-                          // copyVerse();
+                          copyVerse();
                         }),
                   ),
                 ],

--- a/lib/services/bible_source.dart
+++ b/lib/services/bible_source.dart
@@ -16,7 +16,6 @@ class BibleSource {
 
   static Future<List<String>> readAsLines(
       BuildContext context, String filePath) async {
-    print('jesus christ');
     return DefaultAssetBundle.of(context)
         .loadString(filePath)
         .then((str) => str.split('\n'))


### PR DESCRIPTION
closes #7 

Implemented logic to take what's in `_CardInterfaceState`, format the passage, and put it into the clipboard.

I noticed whenever I press the copy button:
```═══════ Exception caught by services library ══════════════════════════════════
The following StateError was thrown during a platform message response callback:
Bad state: Future already completed

When the exception was thrown, this was the stack
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 195:49  throw_
dart-sdk/lib/async/future_impl.dart 42:79                                     complete
packages/flutter/src/services/binding.dart 176:18                             <fn>
dart-sdk/lib/async/zone.dart 1374:10                                          runUnaryGuarded
lib/_engine/engine/window.dart 331:23                                         <fn>
...
```
Will need to look into why this message is occurring. Doesn't seem to break the core feature though.