### PR TITLE
Copy read verses using JS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,8 @@ import 'package:interprep/services/formatter/two_line_format.dart';
 import 'services/bible/korean_bible.dart';
 import 'services/bible/nkjv_bible.dart';
 
+import 'dart:js' as js;
+
 void main() => runApp(Interprep());
 
 class Interprep extends StatelessWidget {
@@ -155,7 +157,12 @@ class _CardInterfaceState extends State<CardInterface> {
   void copyVerse() {
     final str = fetchVersesToCopy();
     if (str == null) return;
-    Clipboard.setData(ClipboardData(text: str));
+
+    if (_verseStatus == VerseStatus.read) {
+      js.context.callMethod('copyToClip', [str]);
+    } else {
+      Clipboard.setData(ClipboardData(text: str));
+    }
   }
 
   String fetchVersesToCopy() {
@@ -172,11 +179,18 @@ class _CardInterfaceState extends State<CardInterface> {
     String str;
     if (_verseStatus == VerseStatus.recited) {
       final locationFirst = _verseLocation == VerseLocation.before;
-      str = TwoLineFormat().formatPassagePair(korean, nkjv,
-          locationFirst: locationFirst, useAbbreviation1: true);
+      str = TwoLineFormat().formatPassagePair(
+        korean,
+        nkjv,
+        locationFirst: locationFirst,
+        useAbbreviation1: true,
+      );
     } else {
-      str = TwoColumnFormat()
-          .formatPassagePair(korean, nkjv, useAbbreviation1: true);
+      str = TwoColumnFormat().formatPassagePair(
+        korean,
+        nkjv,
+        useAbbreviation1: true,
+      );
     }
     return str;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -230,7 +230,7 @@ class _CardInterfaceState extends State<CardInterface> {
         ),
         child: Card(
           margin: EdgeInsets.all(15),
-          child: Container(
+          child: SingleChildScrollView(
             padding: EdgeInsets.all(20),
             child: cardContent(context),
           ),
@@ -422,7 +422,7 @@ class _CardInterfaceState extends State<CardInterface> {
               onPressed: copyButtonOnPressed(),
             ),
           ],
-        )
+        ),
       ],
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -262,42 +262,30 @@ class _CardInterfaceState extends State<CardInterface> {
             ),
             Flexible(
               flex: 2,
-              child: Row(
-                children: <Widget>[
-                  Radio(
-                    value: VerseStatus.recited,
-                    groupValue: _verseStatus,
-                    onChanged: (VerseStatus value) {
-                      setState(() {
-                        _verseStatus = value;
-                      });
-                    },
-                  ),
-                  Text(
-                    'Recited',
-                    textAlign: TextAlign.left,
-                  ),
-                ],
+              child: RadioListTile<VerseStatus>(
+                title: Text('Recited'),
+                dense: true,
+                value: VerseStatus.recited,
+                groupValue: _verseStatus,
+                onChanged: (VerseStatus value) {
+                  setState(() {
+                    _verseStatus = value;
+                  });
+                },
               ),
             ),
             Flexible(
               flex: 2,
-              child: Row(
-                children: <Widget>[
-                  Radio(
-                    value: VerseStatus.read,
-                    groupValue: _verseStatus,
-                    onChanged: (VerseStatus value) {
-                      setState(() {
-                        _verseStatus = value;
-                      });
-                    },
-                  ),
-                  Text(
-                    'Read',
-                    textAlign: TextAlign.left,
-                  ),
-                ],
+              child: RadioListTile<VerseStatus>(
+                title: Text('Read'),
+                dense: true,
+                value: VerseStatus.read,
+                groupValue: _verseStatus,
+                onChanged: (VerseStatus value) {
+                  setState(() {
+                    _verseStatus = value;
+                  });
+                },
               ),
             ),
           ],
@@ -320,42 +308,30 @@ class _CardInterfaceState extends State<CardInterface> {
             ),
             Flexible(
               flex: 2,
-              child: Row(
-                children: <Widget>[
-                  Radio(
-                    value: VerseLocation.before,
-                    groupValue: _verseLocation,
-                    onChanged: (VerseLocation value) {
-                      setState(() {
-                        _verseLocation = value;
-                      });
-                    },
-                  ),
-                  Text(
-                    'Before',
-                    textAlign: TextAlign.left,
-                  ),
-                ],
+              child: RadioListTile<VerseLocation>(
+                title: Text('Before'),
+                dense: true,
+                value: VerseLocation.before,
+                groupValue: _verseLocation,
+                onChanged: (VerseLocation value) {
+                  setState(() {
+                    _verseLocation = value;
+                  });
+                },
               ),
             ),
             Flexible(
               flex: 2,
-              child: Row(
-                children: <Widget>[
-                  Radio(
-                    value: VerseLocation.after,
-                    groupValue: _verseLocation,
-                    onChanged: (VerseLocation value) {
-                      setState(() {
-                        _verseLocation = value;
-                      });
-                    },
-                  ),
-                  Text(
-                    'After',
-                    textAlign: TextAlign.left,
-                  ),
-                ],
+              child: RadioListTile<VerseLocation>(
+                title: Text('After'),
+                dense: true,
+                value: VerseLocation.after,
+                groupValue: _verseLocation,
+                onChanged: (VerseLocation value) {
+                  setState(() {
+                    _verseLocation = value;
+                  });
+                },
               ),
             ),
           ],

--- a/web/index.html
+++ b/web/index.html
@@ -29,5 +29,17 @@
     }
   </script>
   <script src="main.dart.js" type="application/javascript"></script>
+  <script>
+    function copyToClip(str) {
+      function listener(e) {
+        e.clipboardData.setData("text/html", str);
+        e.clipboardData.setData("text/plain", str);
+        e.preventDefault();
+      }
+      document.addEventListener("copy", listener);
+      document.execCommand("copy");
+      document.removeEventListener("copy", listener);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
* Replaced the Row[Radio, Text] widgets with `RadioListTiles`.
* Before/After radio buttons now get disabled if the `Read` option is chosen for Recited/Read option.
* Add Javascript function that can be used to copy rich text.